### PR TITLE
Fix log subscriber for >= Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         - gemfiles/rails_5.2.gemfile
         - gemfiles/rails_6.0.gemfile
         - gemfiles/rails_6.1.gemfile
+        - gemfiles/rails_7.0.gemfile
+        - gemfiles/rails_7.1.gemfile
         - Gemfile
         ruby:
-         - 2.5
-         - 2.6
          - 2.7
          - 3.0
          - jruby

--- a/Appraisals
+++ b/Appraisals
@@ -10,6 +10,14 @@ appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
 
+appraise 'rails-7.0' do
+  gem 'rails', '~> 7.0.0'
+end
+
+appraise 'rails-7.1' do
+  gem 'rails', '~> 7.1.0'
+end
+
 appraise 'rails-head' do
   gem 'rails', github: 'rails'
   gem 'arel', github: 'rails/arel'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem "mutex_m"
+gem "bigdecimal"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,5 +3,8 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem "mutex_m"
+gem "bigdecimal"
+gem "drb"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 7.0.0"
 gem "mutex_m"
 gem "bigdecimal"
 gem "drb"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0"
-gem "mutex_m"
-gem "bigdecimal"
-gem "drb"
+gem "rails", "~> 7.1.0"
 
 gemspec path: "../"

--- a/lib/sweet_notifications/log_subscriber.rb
+++ b/lib/sweet_notifications/log_subscriber.rb
@@ -31,9 +31,9 @@ module SweetNotifications
 
       format(
         '  %s (%.2fms)  %s',
-        color(label, label_color, true),
+        color(label, label_color, self.class.as_7_1_or_upper? ? { bold: true } : true),
         event.duration,
-        color(body, nil, !@odd)
+        color(body, nil, self.class.as_7_1_or_upper? ? { bold: !@odd } : !@odd)
       )
     end
 
@@ -73,6 +73,13 @@ module SweetNotifications
           self.class.runtime += event.duration if runtime
           instance_exec(event, &block) if block
         end
+      end
+
+      def as_7_1_or_upper?
+        return @as_7_1_or_upper if defined?(@as_7_1_or_upper)
+
+        @as_7_1_or_upper =
+          Gem::Version.new(ActiveSupport::VERSION::STRING) >= Gem::Version.new('7.1.0')
       end
 
       protected

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -135,8 +135,13 @@ describe SweetNotifications::LogSubscriber do
       subject.colorize_logging = true
       odd = subject.message(event, 'Label', 'body')
       even = subject.message(event, 'Label', 'body')
-      assert odd.exclude?(ActiveSupport::LogSubscriber::BOLD + 'body')
-      assert even.include?(ActiveSupport::LogSubscriber::BOLD + 'body')
+      if Gem::Version.new(ActiveSupport::VERSION::STRING) >= Gem::Version.new('7.1.0')
+        assert odd.exclude?("\e[#{ActiveSupport::LogSubscriber::MODES[:bold]}m" + 'body')
+        assert even.include?("\e[#{ActiveSupport::LogSubscriber::MODES[:bold]}m" + 'body')
+      else
+        assert odd.exclude?(ActiveSupport::LogSubscriber::BOLD + 'body')
+        assert even.include?(ActiveSupport::LogSubscriber::BOLD + 'body')
+      end
     end
 
     it 'does not use colors when setting is disabled' do

--- a/test/railtie_test.rb
+++ b/test/railtie_test.rb
@@ -13,7 +13,7 @@ describe SweetNotifications::Railtie do
     end
 
     it 'attaches log subscriber to namespace' do
-      mock = MiniTest::Mock.new
+      mock = Minitest::Mock.new
       mock.expect :attach_to, true, [:log_subscriber]
       railtie = SweetNotifications.railtie('log_subscriber', mock, Module.new)
       railtie.run_initializers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 ENV['RAILS_ENV'] = 'test'
 require 'simplecov'
+require 'logger'
 
 SimpleCov.start do
   add_filter 'test'
@@ -29,7 +30,7 @@ class ActiveSupport::TestCase
     remove_method :describe if method_defined? :describe
   end
 
-  extend MiniTest::Spec::DSL
+  extend Minitest::Spec::DSL
   register_spec_type(/SweetNotifications$/, ActionController::TestCase)
   register_spec_type(/ControllerRuntime$/, ActionController::TestCase)
   register_spec_type(self)


### PR DESCRIPTION
Current gem version is incompatible with the Rails >= 7.1 due to the following changes:

> Add italic and underline support to ActiveSupport::LogSubscriber#color
>
> Previously, only bold text was supported via a positional argument.
> This allows for bold, italic, and underline options to be specified
> for colored logs.
>
> ```info color("Hello world!", :red, bold: true, underline: true)```

See https://github.com/rails/rails/releases/tag/v7.1.0

This PR:
* adds support for Rails >= 7.1
* fixes CI and incompatibility issues

I removed old Rubies (2.5 and 2.6, left 2.7 for compatibility checks and tests).